### PR TITLE
Move macro from Http to PendingRequest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Moved macro "withCorrelationId" from `Http` to `PendingRequest`.
 
 ## [0.1.0] - 2020-11-06
 

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -2,7 +2,7 @@
 
 namespace Butler\Audit;
 
-use Illuminate\Support\Facades\Http;
+use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Support\ServiceProvider as BaseServiceProvider;
 use Illuminate\Support\Str;
 
@@ -16,7 +16,7 @@ class ServiceProvider extends BaseServiceProvider
 
         $this->app->bind(Auditor::class, fn () => new Auditor(app('butler-audit-correlation-id')));
 
-        Http::macro('withCorrelationId', fn () => $this->withHeaders([
+        PendingRequest::macro('withCorrelationId', fn () => $this->withHeaders([
             'X-Correlation-ID' => app('butler-audit-correlation-id'),
         ]));
     }


### PR DESCRIPTION
This makes it possible to chain "withCorrelationId" on a `PendingRequest`.

```php
// before
Http::withToken('secret')->withCorrelationId()->post('/api'); // BadMethodCallException 
Http::withCorrelationId()->withToken('secret')->post('/api'); // works

// after
Http::withToken('secret')->withCorrelationId()->post('/api'); // works
Http::withCorrelationId()->withToken('secret')->post('/api'); // works
