### PR TITLE
WIP/RFC: Add header for correlation depth

### DIFF
--- a/src/Audit.php
+++ b/src/Audit.php
@@ -141,6 +141,7 @@ class Audit implements ArrayAccess
 
         return [
             'correlationId' => $this->auditor->correlationId(),
+            'correlationDepth' => $this->auditor->correlationDepth(),
             'entities' => $this->entities,
             'event' => $this->event,
             'eventContext' => $this->eventContext,

--- a/src/Bus/Dispatcher.php
+++ b/src/Bus/Dispatcher.php
@@ -17,6 +17,7 @@ class Dispatcher extends BaseDispatcher
     {
         if (in_array(WithCorrelationId::class, class_uses_recursive($command))) {
             $command->correlationId = Auditor::correlationId();
+            $command->correlationDepth = Auditor::correlationDepth();
         }
 
         return parent::dispatchToQueue($command);

--- a/src/Bus/WithCorrelationId.php
+++ b/src/Bus/WithCorrelationId.php
@@ -7,6 +7,7 @@ use Butler\Audit\Jobs\Middleware\SetCorrelationId;
 trait WithCorrelationId
 {
     public $correlationId;
+    public $correlationDepth;
 
     public function middleware()
     {

--- a/src/Facades/Auditor.php
+++ b/src/Facades/Auditor.php
@@ -18,6 +18,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static void assertNothingLogged()
  * @method static void assertLoggedCount(int $count)
  * @method static string correlationId(?string $correlationId = null)
+ * @method static int correlationDepth(?int $correlationDepth = null)
  * @method static ?\Closure initiatorResolver(?\Closure $resolver)
  *
  * @see \Butler\Audit\Auditor

--- a/src/Jobs/Middleware/SetCorrelationId.php
+++ b/src/Jobs/Middleware/SetCorrelationId.php
@@ -11,6 +11,7 @@ class SetCorrelationId
     {
         if (in_array(WithCorrelationId::class, class_uses_recursive($job))) {
             Auditor::correlationId($job->correlationId);
+            Auditor::correlationDepth($job->correlationDepth);
         }
 
         return $next($job);

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -30,7 +30,7 @@ class ServiceProvider extends BaseServiceProvider
     {
         PendingRequest::macro(
             'withCorrelationId',
-            fn () => $this->withHeaders(['X-Correlation-ID' => Auditor::correlationId()])
+            fn () => $this->withHeaders(Auditor::headers())
         );
     }
 
@@ -62,7 +62,10 @@ class ServiceProvider extends BaseServiceProvider
     public function listenForJobProcessedEvent()
     {
         if ($this->app->runningInConsole()) {
-            Queue::after(fn (JobProcessed $event) => Auditor::correlationId(null));
+            Queue::after(function (JobProcessed $event) {
+                Auditor::correlationId(null);
+                Auditor::correlationDepth(null);
+            });
         }
     }
 }

--- a/tests/AuditDataTest.php
+++ b/tests/AuditDataTest.php
@@ -19,6 +19,7 @@ class AuditDataTest extends TestCase
     public function test_fluent_attributes()
     {
         $this->assertEquals('uuid', $this->data->correlationId);
+        $this->assertEquals(0, $this->data->correlationDepth);
         $this->assertEquals('eventName', $this->data->event);
         $this->assertEquals('phpunit', $this->data->initiator);
         $this->assertEquals('2020-11-19T10:38:34+00:00', $this->data->occurredAt);
@@ -46,6 +47,7 @@ class AuditDataTest extends TestCase
     {
         return new AuditData([
             'correlationId' => 'uuid',
+            'correlationDepth' => 0,
             'entities' => [
                 [
                     'type' => 'entityType',

--- a/tests/AuditTest.php
+++ b/tests/AuditTest.php
@@ -178,6 +178,7 @@ class AuditTest extends AbstractTestCase
 
         Auditor::assertLogged('foobarbaz', function (AuditData $data) {
             return $data->correlationId === 'uuid'
+                && $data->correlationDepth === 0
                 && $data->hasEntity('entityType', 'entity-id')
                 && $data->eventContext('foo', 'bar')
                 && $data->eventContext('foo', 'baz')

--- a/tests/DispatcherTest.php
+++ b/tests/DispatcherTest.php
@@ -13,12 +13,13 @@ class DispatcherTest extends AbstractTestCase
         Queue::fake();
 
         Auditor::correlationId('a-correlation-id');
+        Auditor::correlationDepth(1);
 
         dispatch(new JobWithCorrelationId());
 
-        Queue::assertPushed(
-            fn (JobWithCorrelationId $job) => $job->correlationId === 'a-correlation-id'
-        );
+        Queue::assertPushed(fn (JobWithCorrelationId $job)
+            => $job->correlationId === 'a-correlation-id'
+            && $job->correlationDepth === 1);
     }
 
     public function test_it_does_not_set_correlation_id_for_job_not_using_WithCorrelationId_trait()
@@ -30,8 +31,8 @@ class DispatcherTest extends AbstractTestCase
 
         Queue::assertPushed(JobWithoutCorrelationId::class);
 
-        Queue::assertNotPushed(
-            fn (JobWithoutCorrelationId $job) => property_exists($job, 'correlationId')
-        );
+        Queue::assertNotPushed(fn (JobWithoutCorrelationId $job)
+            => property_exists($job, 'correlationId')
+            && property_exists($job, 'correlationDepth'));
     }
 }

--- a/tests/HttpClientTest.php
+++ b/tests/HttpClientTest.php
@@ -8,12 +8,13 @@ use Illuminate\Support\Str;
 
 class HttpClientTest extends AbstractTestCase
 {
-    public function test_macro_withCorrelationId_adds_header_with_correlation_id_from_container()
+    public function test_macro_withCorrelationId_adds_header_with_correlation_id_and_depth()
     {
         Http::fake();
         Http::withCorrelationId()->post('/api');
         Http::assertSent(fn ($request)
             => $request->hasHeader('X-Correlation-ID')
+            && $request->hasHeader('X-Correlation-Depth', 0)
             && Str::isUuid($request->header('X-Correlation-ID')[0]));
     }
 }

--- a/tests/ServiceProviderTest.php
+++ b/tests/ServiceProviderTest.php
@@ -72,7 +72,7 @@ class ServiceProviderTest extends AbstractTestCase
         $this->assertInstanceOf(Dispatcher::class, app(BaseDispatcher::class));
     }
 
-    public function test_correlation_id_is_reset_after_each_queued_job()
+    public function test_correlation_id_and_depth_is_reset_after_each_queued_job()
     {
         $this->assertTrue(app('events')->hasListeners(JobProcessed::class));
 
@@ -81,5 +81,6 @@ class ServiceProviderTest extends AbstractTestCase
         event(new JobProcessed('connection', new JobWithoutCorrelationId()));
 
         $this->assertNotEquals($correlationId, Auditor::correlationId());
+        $this->assertEquals(0, Auditor::correlationDepth());
     }
 }

--- a/tests/SetCorrelationIdTest.php
+++ b/tests/SetCorrelationIdTest.php
@@ -13,10 +13,12 @@ class SetCorrelationIdTest extends AbstractTestCase
 
         $job = new JobWithCorrelationId();
         $job->correlationId = 'correlation-id';
+        $job->correlationDepth = 1;
 
         (new SetCorrelationId())->handle($job, fn ($job) => true);
 
         $this->assertEquals('correlation-id', Auditor::correlationId());
+        $this->assertEquals(1, Auditor::correlationDepth());
     }
 
     public function test_correlation_id_is_not_set_when_job_is_not_using_WithCorrelationId_trait()
@@ -30,5 +32,6 @@ class SetCorrelationIdTest extends AbstractTestCase
         (new SetCorrelationId())->handle($job, fn ($job) => true);
 
         $this->assertEquals($correlationId, Auditor::correlationId());
+        $this->assertEquals(0, Auditor::correlationDepth());
     }
 }


### PR DESCRIPTION
Alternative to #16 

`X-Correlation-ID: abc123, X-Correlation-Depth: 0` # first event
`X-Correlation-ID: abc123, X-Correlation-Depth: 1` # second event
`X-Correlation-ID: abc123, X-Correlation-Depth: n`