### PR TITLE
WIP/RFC: Add header for correlation "root"

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -30,7 +30,7 @@ class ServiceProvider extends BaseServiceProvider
     {
         PendingRequest::macro(
             'withCorrelationId',
-            fn () => $this->withHeaders(['X-Correlation-ID' => Auditor::correlationId()])
+            fn () => $this->withHeaders(Auditor::headers())
         );
     }
 

--- a/tests/HttpClientTest.php
+++ b/tests/HttpClientTest.php
@@ -8,12 +8,13 @@ use Illuminate\Support\Str;
 
 class HttpClientTest extends AbstractTestCase
 {
-    public function test_macro_withCorrelationId_adds_header_with_correlation_id_from_container()
+    public function test_macro_withCorrelationId_adds_headers_from_Auditor()
     {
         Http::fake();
         Http::withCorrelationId()->post('/api');
         Http::assertSent(fn ($request)
             => $request->hasHeader('X-Correlation-ID')
+            && $request->hasHeader('X-Correlation-Root', 1)
             && Str::isUuid($request->header('X-Correlation-ID')[0]));
     }
 }


### PR DESCRIPTION
Alternative to #15 

`X-Correlation-ID: abc123, X-Correlation-Root: 1` # root event
`X-Correlation-ID: abc123` # second event
`X-Correlation-ID: abc123` # ...