### PR TITLE
Make Auditor::initiatorResolver static

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Make Auditor::initiatorResolver static
 
 ## [0.4.0] - 2021-09-23
 

--- a/src/Auditor.php
+++ b/src/Auditor.php
@@ -32,7 +32,7 @@ class Auditor
 
     protected array $recorded = [];
 
-    private $initiatorResolver;
+    private static $initiatorResolver;
 
     public function fake()
     {
@@ -100,10 +100,10 @@ class Auditor
     public function initiatorResolver(?Closure $resolver = null): ?Closure
     {
         if (func_num_args() === 1) {
-            $this->initiatorResolver = $resolver;
+            static::$initiatorResolver = $resolver;
         }
 
-        return $this->initiatorResolver;
+        return static::$initiatorResolver;
     }
 
     public function __call($method, $parameters)


### PR DESCRIPTION
Why? Because octane clears resolved facade instances every request.

Should not be breaking :pray: